### PR TITLE
content/research-app: add forwarder for research-app docs

### DIFF
--- a/content/research-app/_index.md
+++ b/content/research-app/_index.md
@@ -1,0 +1,3 @@
++++
+redirect_to = "research-app/latest/"
++++


### PR DESCRIPTION
We should also link to these docs from the front page somewhere, but I haven't decided where exactly to put them, and the docs are quite sketchy right now.